### PR TITLE
bug(pricing-router): fix update pricing mutation by updating by user id

### DIFF
--- a/src/hooks/useAdminPricing.tsx
+++ b/src/hooks/useAdminPricing.tsx
@@ -21,7 +21,7 @@ export default function useAdminPricing(userId: string) {
     refetch().catch(console.error);
   }, [userId, refetchPricing]);
 
-  const updatePricing = api.pricing.update.useMutation({
+  const updatePricing = api.pricing.updatePricingByUserId.useMutation({
     onSuccess: async () => {
       await refetchPricing();
     },
@@ -36,6 +36,7 @@ export default function useAdminPricing(userId: string) {
   function addPricing() {
     if (!pricing) return;
     updatePricing.mutate({
+      userId: userId,
       zeroToFour: pricingInputs.zeroToFour,
       fourToEight: pricingInputs.fourToEight,
       eightToFifteen: pricingInputs.eightToFifteen,

--- a/src/server/api/routers/pricing.ts
+++ b/src/server/api/routers/pricing.ts
@@ -1,8 +1,7 @@
-import { z } from 'zod';
-import { createTRPCRouter, protectedProcedure } from '../trpc';
-import { pricing } from '~/server/db/schema';
-import { eq } from 'drizzle-orm';
-
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { pricing } from "~/server/db/schema";
+import { eq } from "drizzle-orm";
 
 export const pricingRouter = createTRPCRouter({
   getPricingByUserId: protectedProcedure.input(z.string()).query(({ ctx, input }) => {
@@ -19,7 +18,7 @@ export const pricingRouter = createTRPCRouter({
         fiftyFiveToSixtyFive: true,
         sixtyFiveToSeventy: true,
       },
-    })
+    });
   }),
   getPricing: protectedProcedure.query(({ ctx }) => {
     return ctx.db.query.pricing.findFirst({
@@ -37,9 +36,10 @@ export const pricingRouter = createTRPCRouter({
       },
     });
   }),
-  update: protectedProcedure
+  updatePricingByUserId: protectedProcedure
     .input(
       z.object({
+        userId: z.string(),
         zeroToFour: z.string(),
         fourToEight: z.string(),
         eightToFifteen: z.string(),
@@ -65,6 +65,6 @@ export const pricingRouter = createTRPCRouter({
           fiftyFiveToSixtyFive: input.fiftyFiveToSixtyFive,
           sixtyFiveToSeventy: input.sixtyFiveToSeventy,
         })
-        .where(eq(pricing.userId, ctx.auth.userId));
+        .where(eq(pricing.userId, input.userId));
     }),
 });


### PR DESCRIPTION
Fixes the update mutation in the pricing router to now update by userId

Bug: If you tried updating another users pricing table, it would just update the pricing table for the admin that is currently logged in

Fix: It now should update the selected users pricing table instead of the admin

Take these steps in merging this code:
1. Review all code through github
2. Pull branch and test code
3. Make sure branch is going to be merged in correct branch (in this case, 0.2)
4. Merge code
5. Test 0.2 branch to make sure it doesn't conflict with anything already on it
6. Delete this branch
7. Update monday.com